### PR TITLE
Bridge usernames typed in chat correctly from Slack -> IRC

### DIFF
--- a/slackbridge/bots.py
+++ b/slackbridge/bots.py
@@ -1,6 +1,5 @@
-import time
-
 import re
+import time
 
 from twisted.internet.task import LoopingCall
 from twisted.python import log
@@ -117,10 +116,11 @@ class UserBot(IRCBot):
 
     def __format_message(self, message):
         match_name = re.search(r'<\@([A-Z0-9]{9,})\>', message)
-        if match_name: 
-            user_info = self.sc.api_call('users.info', user=match_name.group(1))
+        if match_name:
+            user_info = self.sc.api_call(
+                'users.info', user=match_name.group(1))
             if user_info['ok']:
-                target_nick = '{}-slack'.format(utils.strip_nick(user_info['user']['name']))
+                target_nick = '{}-slack'.format(
+                    utils.strip_nick(user_info['user']['name']))
                 return message.replace(match_name.group(0), target_nick)
         return message
-    

--- a/slackbridge/bots.py
+++ b/slackbridge/bots.py
@@ -118,7 +118,7 @@ class UserBot(IRCBot):
         # in the same Slack message.
         for replace, uid in set(match_ids):
             user_info = next(
-                (user for user in self.users if user['id'] == uid),
+                (user for user in self.slack_users if user['id'] == uid),
                 None,
             )
             if user_info:

--- a/slackbridge/bots.py
+++ b/slackbridge/bots.py
@@ -115,12 +115,14 @@ class UserBot(IRCBot):
         self.msg(channel, self.__format_message(message))
 
     def __format_message(self, message):
-        match_name = re.search(r'<\@([A-Z0-9]{9,})\>', message)
-        if match_name:
+        match_ids = re.findall(r'(<\@([A-Z0-9]{9,})\>)', message)
+        # If for some weird reason someone mentions the same person
+        # twice in one message, we avoid extra api calls
+        for replace, uid in set(match_ids):
             user_info = self.sc.api_call(
-                'users.info', user=match_name.group(1))
+                'users.info', user=uid)
             if user_info['ok']:
                 target_nick = '{}-slack'.format(
                     utils.strip_nick(user_info['user']['name']))
-                return message.replace(match_name.group(0), target_nick)
+                message = message.replace(replace, target_nick)
         return message

--- a/slackbridge/factories.py
+++ b/slackbridge/factories.py
@@ -34,7 +34,7 @@ class BridgeBotFactory(BotFactory):
         # server and their own nicknames
         for user in users:
             user_factory = UserBotFactory(
-                self, user, channels,
+                slack_client, self, user, channels,
             )
             reactor.connectSSL(
                 IRC_HOST, IRC_PORT, user_factory, ssl.ClientContextFactory()
@@ -53,7 +53,8 @@ class BridgeBotFactory(BotFactory):
 
 class UserBotFactory(BotFactory):
 
-    def __init__(self, bridge_bot_factory, slack_user, channels):
+    def __init__(self, slack_client, bridge_bot_factory, slack_user, channels):
+        self.slack_client = slack_client
         self.bridge_bot_factory = bridge_bot_factory
         self.slack_user = slack_user
         self.channels = []
@@ -63,7 +64,8 @@ class UserBotFactory(BotFactory):
                 self.channels.append(channel)
 
     def buildProtocol(self, addr):
-        p = UserBot(self.slack_user['name'],
+        p = UserBot(self.slack_client,
+                    self.slack_user['name'],
                     self.slack_user['real_name'],
                     self.slack_user['id'], self.channels)
         p.factory = self

--- a/slackbridge/factories.py
+++ b/slackbridge/factories.py
@@ -32,7 +32,7 @@ class BridgeBotFactory(BotFactory):
         self.user_bots = []
 
         # Give all bots access to the slack userlist
-        IRCBot.users = users
+        IRCBot.slack_users = users
 
         # Create individual user bots with their own connections to the IRC
         # server and their own nicknames

--- a/slackbridge/factories.py
+++ b/slackbridge/factories.py
@@ -34,7 +34,7 @@ class BridgeBotFactory(BotFactory):
         # server and their own nicknames
         for user in users:
             user_factory = UserBotFactory(
-                slack_client, self, user, channels,
+                self, user, users, channels,
             )
             reactor.connectSSL(
                 IRC_HOST, IRC_PORT, user_factory, ssl.ClientContextFactory()
@@ -53,10 +53,10 @@ class BridgeBotFactory(BotFactory):
 
 class UserBotFactory(BotFactory):
 
-    def __init__(self, slack_client, bridge_bot_factory, slack_user, channels):
-        self.slack_client = slack_client
+    def __init__(self, bridge_bot_factory, slack_user, users, channels):
         self.bridge_bot_factory = bridge_bot_factory
         self.slack_user = slack_user
+        self.users = users
         self.channels = []
 
         for channel in channels:
@@ -64,10 +64,10 @@ class UserBotFactory(BotFactory):
                 self.channels.append(channel)
 
     def buildProtocol(self, addr):
-        p = UserBot(self.slack_client,
-                    self.slack_user['name'],
+        p = UserBot(self.slack_user['name'],
                     self.slack_user['real_name'],
-                    self.slack_user['id'], self.channels)
+                    self.slack_user['id'],
+                    self.users, self.channels)
         p.factory = self
         self.bridge_bot_factory.add_user_bot(p)
         self.resetDelay()


### PR DESCRIPTION
A start to resolving #15. Regex searches a message for usernames enclosed in <@...> and replaces that substring with their username before sending the message to irc.