### PR TITLE
Revert "Bridge usernames typed in chat correctly from Slack -> IRC"

### DIFF
--- a/slackbridge/bots.py
+++ b/slackbridge/bots.py
@@ -1,4 +1,3 @@
-import re
 import time
 
 from twisted.internet.task import LoopingCall
@@ -18,6 +17,7 @@ class BridgeBot(IRCBot):
                  user_bots):
         self.topics = {}
         self.user_bots = user_bots
+        self.sc = sc
         self.nickserv_password = nickserv_pw
         self.slack_uid = slack_uid
         self.users = {bot.user_id: bot for bot in user_bots}
@@ -130,20 +130,4 @@ class UserBot(IRCBot):
         self.away('Default away for startup.')
 
     def post_to_irc(self, channel, message):
-        self.msg(channel, self._format_message(message))
-
-    def _format_message(self, message):
-        match_ids = re.findall(r'(<\@([A-Z0-9]{9,})\>)', message)
-        # Avoid duplicate searches for multiple users mentions
-        # in the same Slack message.
-        for replace, uid in set(match_ids):
-            user_info = next(
-                (user for user in self.slack_users if user['id'] == uid),
-                None,
-            )
-            if user_info:
-                target_nick = '{}-slack'.format(
-                    utils.strip_nick(user_info['name']),
-                )
-                message = message.replace(replace, target_nick)
-        return message
+        self.msg(channel, message)

--- a/slackbridge/factories.py
+++ b/slackbridge/factories.py
@@ -4,7 +4,6 @@ from twisted.internet.protocol import ReconnectingClientFactory
 from twisted.python import log
 
 from slackbridge.bots import BridgeBot
-from slackbridge.bots import IRCBot
 from slackbridge.bots import UserBot
 from slackbridge.utils import IRC_HOST
 from slackbridge.utils import IRC_PORT
@@ -32,9 +31,6 @@ class BridgeBotFactory(BotFactory):
         self.channels = channels
         self.bot_class = BridgeBot
         self.user_bots = []
-
-        # Give all bots access to the slack userlist
-        IRCBot.slack_users = users
 
         # Create individual user bots with their own connections to the IRC
         # server and their own nicknames


### PR DESCRIPTION
Reverts ocf/slackbridge#28

Missing a line. Crashing slackbridge.