### PR TITLE
Refactor user and channel storage

### DIFF
--- a/slackbridge/factories.py
+++ b/slackbridge/factories.py
@@ -80,7 +80,7 @@ class UserBotFactory(BotFactory):
         self.target_group_nick = target_group
         self.nickserv_password = nickserv_pw
 
-        for channel_id, channel in IRCBot.channels.items():
+        for channel in IRCBot.channels.values():
             if slack_user['id'] in channel['members']:
                 self.joined_channels.append(channel['name'])
 

--- a/slackbridge/messages.py
+++ b/slackbridge/messages.py
@@ -1,0 +1,90 @@
+import functools
+import time
+
+from twisted.python import log
+
+# Subtypes of messages we don't want mirrored to IRC
+IGNORED_MSG_SUBTYPES = (
+    # Joins and leaves are already shown by IRC when the bot joins/leaves, so
+    # we don't need these. The leave messages actually are already not shown
+    # because the bot exits, then gets the message, so it never gets posted.
+    'channel_join',
+    'channel_leave',
+)
+
+
+@functools.total_ordering
+class SlackMessage:
+    def __init__(self, raw_message, bridge_bot):
+        self.raw_message = raw_message
+        self.bridge_bot = bridge_bot
+
+        if 'ts' in raw_message:
+            self.timestamp = float(raw_message['ts'])
+        else:
+            self.timestamp = time.time()
+
+    def resolve(self):
+        if ('type' not in self.raw_message or
+                'user' not in self.raw_message or
+                'bot_id' in self.raw_message):
+            return
+
+        message_type = self.raw_message['type']
+
+        if self.raw_message['type'] == 'team_join':
+            """Instantiate a new bot user with the user's information"""
+            self.bridge_bot.factory.instantiate_bot(self.raw_message['user'])
+            return
+
+        user = self.raw_message['user']
+        if not isinstance(user, str) or user not in self.bridge_bot.users:
+            return
+
+        user_bot = self.bridge_bot.users[user]
+
+        if message_type == 'presence_change':
+            self._change_presence(user_bot)
+            return
+
+        if 'channel' not in self.raw_message:
+            return
+
+        channel_id = self.raw_message['channel']
+        if channel_id in self.bridge_bot.channels:
+            channel_name = self.bridge_bot.channels[channel_id]['name']
+            if message_type == 'message':
+                if 'subtype' in self.raw_message:
+                    if self.raw_message['subtype'] in IGNORED_MSG_SUBTYPES:
+                        return
+                    # TODO: support file uploads here (file_share subtype)
+
+                log.msg('Posting message to IRC')
+                self._post_to_irc(channel_name, user_bot)
+            elif message_type == 'member_joined_channel':
+                user_bot.join(channel_name)
+            elif message_type == 'member_left_channel':
+                user_bot.leave(channel_name)
+            return
+
+    def _change_presence(self, user_bot):
+        if self.raw_message['presence'] == 'away':
+            user_bot.away('Slack user inactive.')
+        elif self.raw_message['presence'] == 'active':
+            user_bot.back()
+
+    def _post_to_irc(self, channel_name, user_bot):
+        user_bot.post_to_irc(
+            '#' + channel_name, self.raw_message['text'])
+
+    # For PriorityQueue to order by timestamp, override comparisons.
+    # @total_ordering generates the other comparisons given the two below.
+    def __lt__(self, other):
+        if not hasattr(other, 'timestamp'):
+            return NotImplemented
+        return self.timestamp < other.timestamp
+
+    def __eq__(self, other):
+        if not hasattr(other, 'timestamp'):
+            return NotImplemented
+        return self.timestamp == other.timestamp


### PR DESCRIPTION
This simplifies the storage of the mappings of users and channels to store them in the `IRCBot` class instead of passing them around everywhere. As @kkuehler mentioned on IRC/Slack to me already, the channel mapping stuff could be done even earlier, in `main.py` or something, but the user mapping can't be done until the factories start, because it maps user IDs to bots, which aren't available until later.