### PR TITLE
IRC -> Slack tagging

### DIFF
--- a/slackbridge/bots.py
+++ b/slackbridge/bots.py
@@ -17,6 +17,7 @@ class IRCBot(irc.IRCClient):
     channels = {}
     channel_name_to_uid = {}
     users = {}
+    slack_nicks = []
     # Used to download slack files
     slack_token = None
 
@@ -65,13 +66,12 @@ class BridgeBot(IRCBot):
 
     def post_to_slack(self, user, channel, message):
         nick = utils.nick_from_irc_user(user)
-
         # Don't post to Slack if it came from a Slack bot
         if '-slack' not in nick and nick != 'defaultnick':
             log.msg(self.sc.api_call(
                 'chat.postMessage',
                 channel=channel,
-                text=utils.format_slack_message(message),
+                text=utils.format_slack_message(message, IRCBot.slack_nicks),
                 as_user=False,
                 username=nick,
                 icon_url=utils.user_to_gravatar(nick),

--- a/slackbridge/bots.py
+++ b/slackbridge/bots.py
@@ -117,6 +117,7 @@ class UserBot(IRCBot):
 
     def __init__(self, nickname, realname, user_id, joined_channels,
                  target_group, nickserv_pw):
+        self.slack_name = nickname
         self.nickname = '{}-slack'.format(utils.strip_nick(nickname))
         self.realname = realname
         self.user_id = user_id

--- a/slackbridge/bots.py
+++ b/slackbridge/bots.py
@@ -17,7 +17,6 @@ class IRCBot(irc.IRCClient):
     channels = {}
     channel_name_to_uid = {}
     users = {}
-    slack_nicks = []
     # Used to download slack files
     slack_token = None
 
@@ -71,7 +70,7 @@ class BridgeBot(IRCBot):
             log.msg(self.sc.api_call(
                 'chat.postMessage',
                 channel=channel,
-                text=utils.format_slack_message(message, IRCBot.slack_nicks),
+                text=utils.format_slack_message(message, IRCBot.users),
                 as_user=False,
                 username=nick,
                 icon_url=utils.user_to_gravatar(nick),

--- a/slackbridge/factories.py
+++ b/slackbridge/factories.py
@@ -57,6 +57,7 @@ class BridgeBotFactory(BotFactory):
 
     def add_user_bot(self, user_bot):
         IRCBot.users[user_bot.user_id] = user_bot
+        IRCBot.slack_nicks.append(user_bot.nickname.split('-')[0])
 
     def instantiate_bot(self, user):
         user_factory = UserBotFactory(

--- a/slackbridge/factories.py
+++ b/slackbridge/factories.py
@@ -57,7 +57,7 @@ class BridgeBotFactory(BotFactory):
 
     def add_user_bot(self, user_bot):
         IRCBot.users[user_bot.user_id] = user_bot
-        IRCBot.slack_nicks.append(user_bot.nickname.split('-')[0])
+        IRCBot.slack_nicks.append(user_bot.slack_name)
 
     def instantiate_bot(self, user):
         user_factory = UserBotFactory(

--- a/slackbridge/factories.py
+++ b/slackbridge/factories.py
@@ -57,7 +57,6 @@ class BridgeBotFactory(BotFactory):
 
     def add_user_bot(self, user_bot):
         IRCBot.users[user_bot.user_id] = user_bot
-        IRCBot.slack_nicks.append(user_bot.slack_name)
 
     def instantiate_bot(self, user):
         user_factory = UserBotFactory(

--- a/slackbridge/utils.py
+++ b/slackbridge/utils.py
@@ -185,14 +185,16 @@ def format_slack_message(text, users):
 
     def nick_replace(match):
         """
-        Replace any IRC nick of the form keur to <@keur> if it exists in
+        Replace any IRC nick of the form keur-slack to <@keur> if it's in
         the provided list of Slack display names. To prevent accidental
         conversions, "no-more-slack" will not be converted to "<@no-more>",
         assuming no user has the display name "no-more" in the Workspace.
         """
         nick = match.group(1)
-        if nick in users:
-            return '<@{}>'.format(nick)
+        for user in users.values():
+            if nick == user.slack_name:
+                return '<@{}>'.format(nick)
+        return match.group(0)
 
     text = re.sub(r'\x03(?:\d{1,2}(?:,\d{1,2})?)?', '', text, flags=re.UNICODE)
     # we can be greedy here; nick is checked against valid list of users


### PR DESCRIPTION
IRC users are used to pinging a user simply by typing a nick.
This patch provides that functionality, albeit in a
heavy-handed manner.

Fixes #47