### PR TITLE
add support for private messaging

### DIFF
--- a/slackbridge/bots.py
+++ b/slackbridge/bots.py
@@ -110,7 +110,7 @@ class BridgeBot(IRCBot):
         while not self.message_queue.empty():
             message = self.message_queue.get()
             message.resolve()
-    """ #temp: block out setting topic to avoid spamming
+
     # Implements the IRCClient event handler of the same name,
     # which gets called when the topic changes, or when
     # a channel is entered for the first time.
@@ -123,7 +123,6 @@ class BridgeBot(IRCBot):
                 channel=channel_uid,
                 topic=new_topic
             )
-    """
 
     def irc_330(self, prefix, params):
         """

--- a/slackbridge/bots.py
+++ b/slackbridge/bots.py
@@ -30,8 +30,8 @@ class IRCBot(irc.IRCClient):
         self.nickname = nickname
         self.nickserv_password = nickserv_pw
 
-    def post_to_slack(self, user, channel, message, resolve_nick=True):
-        if resolve_nick:
+    def post_to_slack(self, user, channel, message, unparsed_nick=True):
+        if unparsed_nick:
             nick = utils.nick_from_irc_user(user)
         else:
             nick = user
@@ -176,10 +176,8 @@ class BridgeBot(IRCBot):
 
     def verify_auth(self, current_nickname, authenticated_name):
         user = self.irc_users[current_nickname]
-        if current_nickname == authenticated_name:
-            user.authenticated = True
-        else:
-            user.authenticated = False
+
+        user.authenticated = (current_nickname == authenticated_name)
 
     def end_whois(self, user):
         message_copy = self.irc_users[user].messages

--- a/slackbridge/bots.py
+++ b/slackbridge/bots.py
@@ -98,7 +98,7 @@ class BridgeBot(IRCBot):
         while not self.message_queue.empty():
             message = self.message_queue.get()
             message.resolve()
-
+    """ #temp: block out setting topic to avoid spamming
     # Implements the IRCClient event handler of the same name,
     # which gets called when the topic changes, or when
     # a channel is entered for the first time.
@@ -111,11 +111,12 @@ class BridgeBot(IRCBot):
                 channel=channel_uid,
                 topic=new_topic
             )
+    """
 
 
 class UserBot(IRCBot):
 
-    def __init__(self, sc, nickname, realname, user_id, joined_channels, 
+    def __init__(self, sc, nickname, realname, user_id, joined_channels,
                  target_group, nickserv_pw):
         self.sc = sc
         self.slack_name = nickname
@@ -151,30 +152,30 @@ class UserBot(IRCBot):
                 self.target_group_nick,
                 self.nickserv_password,
             ))
+
     def privmsg(self, user, channel, message):
         """
         Set to handle if channel is own name (private chat)
         """
-
         nick = utils.nick_from_irc_user(user)
-        
+
         if channel == self.nickname:
             if not self.im_id:
                 self.im_id = self.sc.api_call(
-                        'im.open',
-                        user=self.user_id,
-                        return_im=True
-                        )['channel']['id']
+                    'im.open',
+                    user=self.user_id,
+                    return_im=True
+                )['channel']['id']
 
             log.msg(self.sc.api_call(
                 'chat.postMessage',
                 channel=self.im_id,
-                text=utils.format_slack_message(nick + ": " + message, IRCBot.users),
+                text=utils.format_slack_message(
+                    nick + ': ' + message, IRCBot.users),
                 as_user=False,
                 username=nick,
                 icon_url=utils.user_to_gravatar(nick),
             ))
-                
 
     def setNick(self, nickname):
         """

--- a/slackbridge/bots.py
+++ b/slackbridge/bots.py
@@ -115,8 +115,8 @@ class BridgeBot(IRCBot):
 
 class UserBot(IRCBot):
 
-    def __init__(self, nickname, realname, user_id, joined_channels,
-                 target_group, nickserv_pw):
+    def __init__(self, sc, nickname, realname, user_id, joined_channels, target_group, nickserv_pw):
+        self.sc = sc
         self.slack_name = nickname
         self.nickname = '{}-slack'.format(utils.strip_nick(nickname))
         self.intended_nickname = self.nickname
@@ -149,6 +149,22 @@ class UserBot(IRCBot):
                 self.target_group_nick,
                 self.nickserv_password,
             ))
+    def privmsg(self, user, channel, message):
+        """
+        Set to handle of channel is own name (private chat)
+        """
+        nick = utils.nick_from_irc_user(user)
+        if channel == self.nickname:
+            channel = self.user_id
+            log.msg(self.sc.api_call(
+                'chat.postMessage',
+                channel=channel,
+                text=utils.format_slack_message(message, IRCBot.users),
+                as_user=False,
+                username=nick,
+                icon_url=utils.user_to_gravatar(nick),
+            ))
+                
 
     def setNick(self, nickname):
         """

--- a/slackbridge/bots.py
+++ b/slackbridge/bots.py
@@ -244,11 +244,13 @@ class UserBot(IRCBot):
         """
         if channel == self.nickname:
             if not self.im_id:
-                self.im_id = self.sc.api_call(
+                im_channel = self.sc.api_call(
                     'im.open',
                     user=self.user_id,
                     return_im=True
-                )['channel']['id']
+                )
+                self.im_id = im_channel['channel']['id']
+
             nick = utils.nick_from_irc_user(user)
             self.post_to_slack(user, self.im_id, nick + ': ' + message)
 

--- a/slackbridge/factories.py
+++ b/slackbridge/factories.py
@@ -73,7 +73,8 @@ class BridgeBotFactory(BotFactory):
 
 class UserBotFactory(BotFactory):
 
-    def __init__(self, slack_client, bridge_bot_factory, slack_user, target_group, nickserv_pw):
+    def __init__(self, slack_client, bridge_bot_factory, slack_user, 
+                 target_group, nickserv_pw):
         self.slack_client = slack_client
         self.bridge_bot_factory = bridge_bot_factory
         self.slack_user = slack_user

--- a/slackbridge/factories.py
+++ b/slackbridge/factories.py
@@ -73,7 +73,7 @@ class BridgeBotFactory(BotFactory):
 
 class UserBotFactory(BotFactory):
 
-    def __init__(self, slack_client, bridge_bot_factory, slack_user, 
+    def __init__(self, slack_client, bridge_bot_factory, slack_user,
                  target_group, nickserv_pw):
         self.slack_client = slack_client
         self.bridge_bot_factory = bridge_bot_factory

--- a/slackbridge/factories.py
+++ b/slackbridge/factories.py
@@ -60,6 +60,7 @@ class BridgeBotFactory(BotFactory):
 
     def instantiate_bot(self, user):
         user_factory = UserBotFactory(
+            self.slack_client,
             self,
             user,
             self.bridge_nickname,
@@ -72,8 +73,8 @@ class BridgeBotFactory(BotFactory):
 
 class UserBotFactory(BotFactory):
 
-    def __init__(self, bridge_bot_factory, slack_user, target_group,
-                 nickserv_pw):
+    def __init__(self, slack_client, bridge_bot_factory, slack_user, target_group, nickserv_pw):
+        self.slack_client = slack_client
         self.bridge_bot_factory = bridge_bot_factory
         self.slack_user = slack_user
         self.joined_channels = []
@@ -86,6 +87,7 @@ class UserBotFactory(BotFactory):
 
     def buildProtocol(self, addr):
         p = UserBot(
+            self.slack_client,
             self.slack_user['name'],
             self.slack_user['real_name'],
             self.slack_user['id'],

--- a/slackbridge/messages.py
+++ b/slackbridge/messages.py
@@ -23,6 +23,7 @@ class SlackMessage:
     def __init__(self, raw_message, bridge_bot):
         self.raw_message = raw_message
         self.bridge_bot = bridge_bot
+        self.deferred = False
 
         if 'ts' in raw_message:
             self.timestamp = float(raw_message['ts'])
@@ -55,7 +56,7 @@ class SlackMessage:
         channel_id = self.raw_message.get('channel')
         if not channel_id or not isinstance(channel_id, str):
             return
-            # |
+
         if channel_id[0] == 'D':  # DM channels start with a D
             if not user_bot.im_id:
                 user_bot.im_id = channel_id
@@ -63,35 +64,35 @@ class SlackMessage:
             if 'text' in self.raw_message:
                 match = re.search('(.*\w):', self.raw_message['text'])
                 if match:
-                    recipient = match.group(1)
-                    if recipient in self.bridge_bot.irc_users:
-                        irc_user = self.bridge_bot.irc_users[recipient]
+                    rcpt = match.group(1)
+                    if rcpt in self.bridge_bot.irc_users and self.deferred:
+                        irc_user = self.bridge_bot.irc_users[rcpt]
                         if irc_user.authenticated:
                             self.raw_message['text'] = \
                                 self.raw_message['text']\
                                 .replace(match.group(0), '')\
                                 .strip()
 
-                            self._post_pm_to_irc(recipient, user_bot)
+                            self._post_pm_to_irc(rcpt, user_bot)
                             return
                         else:
                             self.bridge_bot.post_to_slack(
                                 self.bridge_bot.nickname,
                                 channel_id,
-                                'Error: ' + recipient + ' is '
+                                'Error: ' + rcpt + ' is '
                                 'either not online or not authenticated '
                                 'with NickServ. '
                                 'Message(s) were not delivered.', False)
-
-                            self.bridge_bot.authenticate(recipient)
                             return
                     else:
                         # Defer message and attempt to authenticate user
                         # Afterwards this message is re-resolved
-                        self.bridge_bot.irc_users[recipient] = IRCUser()
-                        self.bridge_bot.irc_users[recipient].add_message(self)
+                        self.deferred = True
 
-                        self.bridge_bot.authenticate(recipient)
+                        self.bridge_bot.irc_users[rcpt] = IRCUser()
+                        self.bridge_bot.irc_users[rcpt].add_message(self)
+
+                        self.bridge_bot.authenticate(rcpt)
                         return
 
                 else:

--- a/slackbridge/messages.py
+++ b/slackbridge/messages.py
@@ -62,15 +62,17 @@ class SlackMessage:
                 user_bot.im_id = channel_id
 
             if 'text' in self.raw_message:
-                match = re.search('(.*\w):', self.raw_message['text'])
+                match = re.search('^(([^:]+):).*$', self.raw_message['text'])
                 if match:
-                    rcpt = match.group(1)
+                    rcpt = match.group(2)
+
                     if rcpt in self.bridge_bot.irc_users and self.deferred:
                         irc_user = self.bridge_bot.irc_users[rcpt]
                         if irc_user.authenticated:
 
                             msg = self.raw_message['text']
-                            msg = msg.replace(match.group(0), '').strip()
+                            rcpt_quoted = match.group(1)
+                            msg = msg.replace(rcpt_quoted, '').strip()
                             self.raw_message['text'] = msg
 
                             self._post_pm_to_irc(rcpt, user_bot)

--- a/slackbridge/messages.py
+++ b/slackbridge/messages.py
@@ -68,22 +68,23 @@ class SlackMessage:
                     if rcpt in self.bridge_bot.irc_users and self.deferred:
                         irc_user = self.bridge_bot.irc_users[rcpt]
                         if irc_user.authenticated:
-                            self.raw_message['text'] = \
-                                self.raw_message['text']\
-                                .replace(match.group(0), '')\
-                                .strip()
+
+                            msg = self.raw_message['text']
+                            msg = msg.replace(match.group(0), '').strip()
+                            self.raw_message['text'] = msg
 
                             self._post_pm_to_irc(rcpt, user_bot)
-                            return
                         else:
+
+                            resp = 'Error: ' + rcpt + ' is ' \
+                                'either not online or not authenticated ' \
+                                'with NickServ. ' \
+                                'Message(s) were not delivered.'
+
                             self.bridge_bot.post_to_slack(
                                 self.bridge_bot.nickname,
                                 channel_id,
-                                'Error: ' + rcpt + ' is '
-                                'either not online or not authenticated '
-                                'with NickServ. '
-                                'Message(s) were not delivered.', False)
-                            return
+                                resp, False)
                     else:
                         # Defer message and attempt to authenticate user
                         # Afterwards this message is re-resolved
@@ -93,15 +94,17 @@ class SlackMessage:
                         self.bridge_bot.irc_users[rcpt].add_message(self)
 
                         self.bridge_bot.authenticate(rcpt)
-                        return
 
                 else:
+
+                    resp = 'Please message an IRC user ' \
+                        'with [username]: [message] '
+
                     self.bridge_bot.post_to_slack(
                         self.bridge_bot.nickname,
                         channel_id,
-                        'Please message an IRC user '
-                        'with [username]: [message] ', False)
-                    return
+                        resp, False)
+
         elif channel_id in self.bridge_bot.channels:
             channel_name = self.bridge_bot.channels[channel_id]['name']
             if message_type == 'message':


### PR DESCRIPTION
#12 

I'm planning to add support for messaging users privately.

**On the IRC -> Slack side:**
Sender /msg's the {user}-slack bot. The message is prepended with the sender's nick and sent via a direct Slack IM Channel from irc-bridge to the Slack user.

on IRC: `/msg jaw-slack testing pm`
on Slack from irc-bridge: `jaw: testing pm`


**On the Slack -> IRC side:**
Current plan is to allow the Slack user to message irc-bridge directly in the format [user]:[message] which will redirect it to the appropriate user on IRC.

I'm also exploring options to use Slack's threads for this feature, but this means we'll have to find a way to handle bot restarts.