### PR TITLE
Fix crash from mentioning @irc-bridge

### DIFF
--- a/slackbridge/bots.py
+++ b/slackbridge/bots.py
@@ -18,6 +18,7 @@ class IRCBot(irc.IRCClient):
     channels = {}
     channel_name_to_uid = {}
     users = {}
+    bots = {}
     # Used to download slack files
     slack_token = None
 
@@ -185,5 +186,6 @@ class UserBot(IRCBot):
         method(channel, utils.format_irc_message(
             message,
             IRCBot.users,
+            IRCBot.bots,
             IRCBot.channels,
         ))

--- a/slackbridge/factories.py
+++ b/slackbridge/factories.py
@@ -51,6 +51,7 @@ class BridgeBotFactory(BotFactory):
             self.nickserv_password,
             self.slack_uid,
         )
+        IRCBot.bots[self.slack_uid] = p
         p.factory = self
         self.resetDelay()
         return p

--- a/slackbridge/utils.py
+++ b/slackbridge/utils.py
@@ -124,7 +124,11 @@ def format_irc_message(text, users, channels):
         """
         user_id = match.group(1)
         readable = match.group(2)
-        return readable or users[user_id].nickname
+
+        if readable or user_id in users:
+            return readable or users[user_id].nickname
+        else:
+            return '(bot)'
 
     def var_replace(match):
         """

--- a/slackbridge/utils.py
+++ b/slackbridge/utils.py
@@ -96,7 +96,7 @@ def nick_from_irc_user(irc_user):
     return irc_user.split('!')[0]
 
 
-def format_irc_message(text, users, channels):
+def format_irc_message(text, users, bots, channels):
     """
     Replace channels, users, commands, links, emoji, and any remaining stuff in
     messages from Slack to things that IRC users would have an easier time
@@ -127,8 +127,10 @@ def format_irc_message(text, users, channels):
 
         if readable or user_id in users:
             return readable or users[user_id].nickname
+        elif user_id in bots:
+            return bots[user_id].nickname
         else:
-            return '(bot)'
+            return 'unknown'
 
     def var_replace(match):
         """

--- a/slackbridge/utils.py
+++ b/slackbridge/utils.py
@@ -130,6 +130,7 @@ def format_irc_message(text, users, bots, channels):
         elif user_id in bots:
             return bots[user_id].nickname
         else:
+            # This should never occur
             return 'unknown'
 
     def var_replace(match):


### PR DESCRIPTION
#51 

Adds a global lookup for bots much like 'users', and modifies the `format_irc_message` method to also lookup bots. 