### PR TITLE
 Intial pass at type annotating slackbridge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test: venv install-hooks mypy
 
 .PHONY: mypy
 mypy: venv
-		venv/bin/mypy --ignore-missing-imports -p slackbridge --check-untyped-defs
+		venv/bin/mypy -p slackbridge
 
 .PHONY: dev
 dev: venv

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,11 @@ DOCKER_REVISION ?= testing-$(USER)
 DOCKER_TAG = docker-push.ocf.berkeley.edu/slackbridge:$(DOCKER_REVISION)
 
 .PHONY: test
-test: venv install-hooks
+test: venv install-hooks mypy
 		venv/bin/pre-commit run --all-files
+
+.PHONY: mypy
+mypy: venv
 		venv/bin/mypy --ignore-missing-imports -p slackbridge --check-untyped-defs
 
 .PHONY: dev

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,12 @@
+[mypy]
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+warn_no_return = True
+strict_optional = True
+no_implicit_optional = True
+disallow_any_generics = True
+warn_redundant_casts = True
+warn_unused_configs = True
+show_traceback = True
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+disallow_untyped_calls = True
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 check_untyped_defs = True

--- a/slackbridge/bots.py
+++ b/slackbridge/bots.py
@@ -1,9 +1,13 @@
 import time
 from queue import PriorityQueue
 from typing import Any
+from typing import Callable
 from typing import Dict
+from typing import List
 from typing import Optional
+from typing import TypeVar
 
+from slackclient import SlackClient
 from twisted.internet import reactor
 from twisted.internet.task import LoopingCall
 from twisted.python import log
@@ -13,28 +17,36 @@ import slackbridge.utils as utils
 from slackbridge.messages import IRCUser
 from slackbridge.messages import SlackMessage
 
+T = TypeVar('T')
+
 
 class IRCBot(irc.IRCClient):
     # Global-ish lookup tables for users/channels by id to make it so this
     # information is not passed around everywhere and to not have to make a
     # Slack API call each time this information is wanted, since it doesn't
     # change often and can be updated by events.
-    channels: Dict[str, Dict[str, Any]] = {}
+    channels: Dict[str, Any] = {}
     channel_name_to_uid: Dict[str, str] = {}
     users: Dict[str, Any] = {}
     bots: Dict[str, Any] = {}
     # Used to download slack files
     slack_token: Optional[str] = None
-    sc = None
+    sc: SlackClient = None
     # Used to store lookup and deferred private messages
-    irc_users: Dict[str, str] = {}
+    irc_users: Dict[str, Any] = {}
 
-    def __init__(self, sc, nickname, nickserv_pw):
+    def __init__(self, sc: SlackClient, nickname: str, nickserv_pw: str):
         self.sc = sc
         self.nickname = nickname
         self.nickserv_password = nickserv_pw
 
-    def post_to_slack(self, user, channel, message, unparsed_nick=True):
+    def post_to_slack(
+        self,
+        user: str,
+        channel: str,
+        message: str,
+        unparsed_nick: bool = True,
+    ) -> None:
         if unparsed_nick:
             nick = utils.nick_from_irc_user(user)
         else:
@@ -54,7 +66,13 @@ class IRCBot(irc.IRCClient):
 
 class BridgeBot(IRCBot):
 
-    def __init__(self, sc, bridge_nick, nickserv_pw, slack_uid):
+    def __init__(
+        self,
+        sc: SlackClient,
+        bridge_nick: str,
+        nickserv_pw: str,
+        slack_uid: str,
+    ):
         self.slack_uid = slack_uid
         self.message_queue: PriorityQueue[SlackMessage] = PriorityQueue()
 
@@ -72,14 +90,14 @@ class BridgeBot(IRCBot):
         message_loop = LoopingCall(self.empty_queue)
         message_loop.start(0.5)
 
-    def rtm_connect(self):
+    def rtm_connect(self) -> None:
         # Attempt to connect to Slack RTM
         while not self.sc.rtm_connect(auto_reconnect=True):
             log.err('Could not connect to Slack RTM, check token/rate limits')
             time.sleep(5)
         log.msg('Connected successfully to Slack RTM')
 
-    def signedOn(self):
+    def signedOn(self) -> None:
         self.msg('NickServ', 'identify {}'.format(self.nickserv_password))
         log.msg('Authenticated with NickServ')
 
@@ -87,13 +105,13 @@ class BridgeBot(IRCBot):
             log.msg('Joining #{}'.format(channel['name']))
             self.join('#{}'.format(channel['name']))
 
-    def privmsg(self, user, channel, message):
+    def privmsg(self, user: str, channel: str, message: str) -> None:
         self.post_to_slack(user, channel, message)
 
-    def action(self, user, channel, message):
+    def action(self, user: str, channel: str, message: str) -> None:
         self.post_to_slack(user, channel, '_{}_'.format(message))
 
-    def check_slack_rtm(self):
+    def check_slack_rtm(self) -> None:
         try:
             message_list = self.sc.rtm_read()
         except TimeoutError:
@@ -110,7 +128,7 @@ class BridgeBot(IRCBot):
             if 'type' in message:
                 self.message_queue.put(SlackMessage(message, self))
 
-    def empty_queue(self):
+    def empty_queue(self) -> None:
         while not self.message_queue.empty():
             message = self.message_queue.get()
             message.resolve()
@@ -118,7 +136,7 @@ class BridgeBot(IRCBot):
     # Implements the IRCClient event handler of the same name,
     # which gets called when the topic changes, or when
     # a channel is entered for the first time.
-    def topicUpdated(self, user, channel, new_topic):
+    def topicUpdated(self, user: str, channel: str, new_topic: str) -> None:
         channel_uid = self.channel_name_to_uid[channel[1:]]
         last_topic = self.channels[channel_uid]['topic']['value']
         if new_topic != last_topic:
@@ -128,7 +146,7 @@ class BridgeBot(IRCBot):
                 topic=new_topic,
             )
 
-    def irc_330(self, prefix, params):
+    def irc_330(self, prefix: str, params: List[str]) -> None:
         """
         A 330-prefix response after a WHOIS [user] is sent
         if [user] is registered AND authenticated.
@@ -142,7 +160,7 @@ class BridgeBot(IRCBot):
 
         self.verify_auth(current_nickname, authenticated_name)
 
-    def irc_RPL_ENDOFWHOIS(self, prefix, params):
+    def irc_RPL_ENDOFWHOIS(self, prefix: str, params: List[str]) -> None:
         """
         RPL_ENDOFWHOIS signifies end of a WHOIS list for [user].
 
@@ -154,36 +172,46 @@ class BridgeBot(IRCBot):
 
         self.end_whois(user)
 
-    def userRenamed(self, user, newname):
+    def userRenamed(self, user: str, newname: str) -> None:
         self.deauthenticate(user)
         self.deauthenticate(newname)
 
-    def userLeft(self, user, channel):
+    def userLeft(self, user: str, channel: str) -> None:
         self.deauthenticate(user)
 
-    def userQuit(self, user, quitMessage):
+    def userQuit(self, user: str, quitMessage: str) -> None:
         self.deauthenticate(user)
 
-    def userKicked(self, user, channel, kicker, message):
+    def userKicked(
+        self,
+        user: str,
+        channel: str,
+        kicker: str,
+        message: str,
+    ) -> None:
         self.deauthenticate(user)
 
-    def deauthenticate(self, user):
+    def deauthenticate(self, user: str) -> None:
         if user in self.irc_users:
             self.irc_users.pop(user)
 
-    def authenticate(self, user):
+    def authenticate(self, user: str) -> None:
         if user not in self.irc_users:
             self.irc_users[user] = IRCUser()
         else:
             self.irc_users[user].authenticated = False
         self.whois(user)
 
-    def verify_auth(self, current_nickname, authenticated_name):
+    def verify_auth(
+        self,
+        current_nickname: str,
+        authenticated_name: str,
+    ) -> None:
         user = self.irc_users[current_nickname]
 
         user.authenticated = (current_nickname == authenticated_name)
 
-    def end_whois(self, user):
+    def end_whois(self, user: str) -> None:
         message_copy = self.irc_users[user].messages
         for message in message_copy:
             message.resolve()
@@ -193,8 +221,14 @@ class BridgeBot(IRCBot):
 class UserBot(IRCBot):
 
     def __init__(
-        self, sc, nickname, realname, user_id, joined_channels,
-        target_group, nickserv_pw,
+        self,
+        sc: SlackClient,
+        nickname: str,
+        realname: str,
+        user_id: str,
+        joined_channels: List[str],
+        target_group: str,
+        nickserv_pw: str,
     ):
         intended_nickname = '{}-slack'.format(utils.strip_nick(nickname))
 
@@ -209,11 +243,11 @@ class UserBot(IRCBot):
 
         super().__init__(sc, intended_nickname, nickserv_pw)
 
-    def log(self, method, message):
+    def log(self, method: Callable[[str], T], message: str) -> T:
         full_message = '[{}]: {}'.format(self.nickname, message)
         return method(full_message)
 
-    def signedOn(self):
+    def signedOn(self) -> None:
         self.nickserv_auth()
 
         for channel_name in self.joined_channels:
@@ -222,7 +256,7 @@ class UserBot(IRCBot):
 
         self.away('Default away for startup.')
 
-    def nickserv_auth(self):
+    def nickserv_auth(self) -> None:
         if self.nickname == self.intended_nickname:
             # If already registered, authenticate yourself to Nickserv
             self.msg('NickServ', 'IDENTIFY {}'.format(self.nickserv_password))
@@ -235,7 +269,7 @@ class UserBot(IRCBot):
                 ),
             )
 
-    def privmsg(self, user, channel, message):
+    def privmsg(self, user: str, channel: str, message: str) -> None:
         """
         Handler if a private message is received
         by an IRC user bot. In IRC, this is when
@@ -249,18 +283,18 @@ class UserBot(IRCBot):
         message = "hello"
         """
         if channel == self.nickname:
-            if not self.im_id:
+            if self.im_id is None:
                 im_channel = self.sc.api_call(
                     'im.open',
                     user=self.user_id,
                     return_im=True,
                 )
                 self.im_id = im_channel['channel']['id']
-
+            assert self.im_id is not None
             nick = utils.nick_from_irc_user(user)
             self.post_to_slack(user, self.im_id, nick + ': ' + message)
 
-    def setNick(self, nickname):
+    def setNick(self, nickname: str) -> None:
         """
         Called whenever the client wants to set a nickname,
         such as on startup or if there's a collision.
@@ -268,7 +302,7 @@ class UserBot(IRCBot):
         super().setNick(nickname)
         self.nickserv_auth()
 
-    def nickChanged(self, nick):
+    def nickChanged(self, nick: str) -> None:
         """Called when a nickname is successfully changed."""
         super().nickChanged(nick)
         if nick != self.intended_nickname:
@@ -280,17 +314,21 @@ class UserBot(IRCBot):
             )
             reactor.callLater(10, self.setNick, self.intended_nickname)
 
-    def joined(self, channel_name):
+    def joined(self, channel_name: str) -> None:
         """Called by twisted when a channel has been joined"""
         if channel_name not in self.joined_channels:
             self.joined_channels.append(channel_name)
 
-    def left(self, channel_name):
+    def left(self, channel_name: str) -> None:
         """Called by twisted when a channel has been left"""
         if channel_name in self.joined_channels:
             self.joined_channels.remove(channel_name)
 
-    def post_to_irc(self, method, channel, message):
+    def post_to_irc(
+        self,
+        method: Callable[[str, str], Any],
+        channel: str, message: str,
+    ) -> None:
         log.msg('User bot posting message to IRC')
         method(
             channel, utils.format_irc_message(

--- a/slackbridge/factories.py
+++ b/slackbridge/factories.py
@@ -1,9 +1,14 @@
+from typing import Any
+from typing import Dict
 from typing import List
 
+from slackclient import SlackClient
 from twisted.internet import reactor
 from twisted.internet import ssl
+from twisted.internet.interfaces import IAddress
 from twisted.internet.protocol import ReconnectingClientFactory
 from twisted.python import log
+from twisted.python.failure import Failure
 
 from slackbridge.bots import BridgeBot
 from slackbridge.bots import IRCBot
@@ -14,11 +19,11 @@ from slackbridge.utils import IRC_PORT
 
 class BotFactory(ReconnectingClientFactory):
 
-    def clientConnectionLost(self, connector, reason):
+    def clientConnectionLost(self, connector: Any, reason: Failure) -> None:
         log.err('Lost connection.  Reason: {}'.format(reason))
         super().clientConnectionLost(connector, reason)
 
-    def clientConnectionFailed(self, connector, reason):
+    def clientConnectionFailed(self, connector: Any, reason: Failure) -> None:
         log.err('Connection failed. Reason: {}'.format(reason))
         super().clientConnectionFailed(connector, reason)
 
@@ -26,8 +31,13 @@ class BotFactory(ReconnectingClientFactory):
 class BridgeBotFactory(BotFactory):
 
     def __init__(
-        self, slack_client, bridge_nick, nickserv_pw, slack_uid,
-        channels, users,
+        self,
+        slack_client: SlackClient,
+        bridge_nick: str,
+        nickserv_pw: str,
+        slack_uid: str,
+        channels: List[Dict[str, Any]],
+        users: List[Dict[str, Any]],
     ):
         self.slack_client = slack_client
         self.slack_uid = slack_uid
@@ -48,7 +58,7 @@ class BridgeBotFactory(BotFactory):
         for user in users:
             self.instantiate_bot(user)
 
-    def buildProtocol(self, addr):
+    def buildProtocol(self, addr: IAddress) -> BridgeBot:
         p = BridgeBot(
             self.slack_client,
             self.bridge_nickname,
@@ -60,10 +70,10 @@ class BridgeBotFactory(BotFactory):
         self.resetDelay()
         return p
 
-    def add_user_bot(self, user_bot):
+    def add_user_bot(self, user_bot: UserBot) -> None:
         IRCBot.users[user_bot.user_id] = user_bot
 
-    def instantiate_bot(self, user):
+    def instantiate_bot(self, user: Dict[str, Any]) -> None:
         user_factory = UserBotFactory(
             self.slack_client,
             self,
@@ -79,8 +89,12 @@ class BridgeBotFactory(BotFactory):
 class UserBotFactory(BotFactory):
 
     def __init__(
-        self, slack_client, bridge_bot_factory, slack_user,
-        target_group, nickserv_pw,
+        self,
+        slack_client: SlackClient,
+        bridge_bot_factory: BridgeBotFactory,
+        slack_user: Dict[str, Any],
+        target_group: str,
+        nickserv_pw: str,
     ):
         self.slack_client = slack_client
         self.bridge_bot_factory = bridge_bot_factory
@@ -93,7 +107,7 @@ class UserBotFactory(BotFactory):
             if slack_user['id'] in channel['members']:
                 self.joined_channels.append(channel['name'])
 
-    def buildProtocol(self, addr):
+    def buildProtocol(self, addr: IAddress) -> UserBot:
         p = UserBot(
             self.slack_client,
             self.slack_user['name'],

--- a/slackbridge/main.py
+++ b/slackbridge/main.py
@@ -16,7 +16,7 @@ from slackbridge.utils import slack_api
 BRIDGE_NICKNAME = 'slack-bridge'
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         description='OCF IRC to Slack bridge',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,

--- a/slackbridge/messages.py
+++ b/slackbridge/messages.py
@@ -2,10 +2,15 @@ import functools
 import os
 import re
 import time
+from typing import Any
+from typing import Dict
 from typing import List
 
 import requests
 from twisted.python import log
+
+from slackbridge.bots import BridgeBot
+from slackbridge.bots import UserBot
 
 
 # Subtypes of messages we don't want mirrored to IRC
@@ -22,7 +27,7 @@ FILEHOST = 'https://fluffy.cc'
 
 @functools.total_ordering
 class SlackMessage:
-    def __init__(self, raw_message, bridge_bot):
+    def __init__(self, raw_message: Dict[str, Any], bridge_bot: BridgeBot):
         self.raw_message = raw_message
         self.bridge_bot = bridge_bot
         self.deferred = False
@@ -32,7 +37,7 @@ class SlackMessage:
         else:
             self.timestamp = time.time()
 
-    def resolve(self):
+    def resolve(self) -> None:
         if ('type' not in self.raw_message or
                 'user' not in self.raw_message or
                 self.is_bot_user()):
@@ -140,7 +145,7 @@ class SlackMessage:
                 user_bot.leave(channel_name)
             return
 
-    def is_bot_user(self):
+    def is_bot_user(self) -> bool:
         """Sometimes bot_id is not included and other
         times it is passed as None. Checks both cases."""
         return (
@@ -148,20 +153,30 @@ class SlackMessage:
             self.raw_message['bot_id'] is not None
         )
 
-    def _change_presence(self, user_bot):
+    def _change_presence(self, user_bot: UserBot) -> None:
         if self.raw_message['presence'] == 'away':
             user_bot.away('Slack user inactive.')
         elif self.raw_message['presence'] == 'active':
             user_bot.back()
 
-    def _irc_me_action(self, channel_name, user_bot, action):
+    def _irc_me_action(
+        self,
+        channel_name: str,
+        user_bot: UserBot,
+        action: str,
+    ) -> None:
         user_bot.post_to_irc(
             user_bot.describe,
             '#' + channel_name,
             action,
         )
 
-    def _post_to_fluffy(self, channel_name, user_bot, file_data):
+    def _post_to_fluffy(
+        self,
+        channel_name: str,
+        user_bot: UserBot,
+        file_data: Dict[str, Any],
+    ) -> None:
         # Adapted from https://api.slack.com/tutorials/working-with-files
         auth = {'Authorization': 'Bearer {}'.format(
             self.bridge_bot.slack_token,
@@ -218,14 +233,14 @@ class SlackMessage:
             'uploaded a file: ' + location,
         )
 
-    def _post_to_irc(self, channel_name, user_bot):
+    def _post_to_irc(self, channel_name: str, user_bot: UserBot) -> None:
         user_bot.post_to_irc(
             user_bot.msg,
             '#' + channel_name,
             self.raw_message['text'],
         )
 
-    def _post_pm_to_irc(self, irc_recipient, user_bot):
+    def _post_pm_to_irc(self, irc_recipient: str, user_bot: UserBot) -> None:
         user_bot.post_to_irc(
             user_bot.msg,
             irc_recipient,
@@ -234,13 +249,13 @@ class SlackMessage:
 
     # For PriorityQueue to order by timestamp, override comparisons.
     # @total_ordering generates the other comparisons given the two below.
-    def __lt__(self, other):
-        if not hasattr(other, 'timestamp'):
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, SlackMessage):
             return NotImplemented
         return self.timestamp < other.timestamp
 
-    def __eq__(self, other):
-        if not hasattr(other, 'timestamp'):
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SlackMessage):
             return NotImplemented
         return self.timestamp == other.timestamp
 

--- a/slackbridge/utils.py
+++ b/slackbridge/utils.py
@@ -2,8 +2,13 @@ import getpass
 import hashlib
 import re
 import sys
+from typing import Any
+from typing import Dict
+from typing import Match
 
+from slackclient import SlackClient
 from twisted.python import log
+
 
 GRAVATAR_URL = 'http://www.gravatar.com/avatar/{}?s=48&r=any&default=identicon'
 
@@ -52,7 +57,7 @@ EMOJIS = {
 }
 
 
-def user_to_gravatar(user):
+def user_to_gravatar(user: str) -> str:
     """
     We use Gravatar images for users when they are mirrored as a guess that
     they have the same IRC nick as their OCF username, and so the email
@@ -66,7 +71,7 @@ def user_to_gravatar(user):
     return GRAVATAR_URL.format(email_hash.hexdigest())
 
 
-def strip_nick(nick):
+def strip_nick(nick: str) -> str:
     """
     Strip a given Slack nickname to be IRC bot compatible. For instance, Slack
     allows users to have periods (.) in their name, but IRC does not allow
@@ -86,7 +91,7 @@ def strip_nick(nick):
     ])
 
 
-def nick_from_irc_user(irc_user):
+def nick_from_irc_user(irc_user: str) -> str:
     """
     User is like 'jvperrin!Jason@fireball.ocf.berkeley.edu' (nick!ident@host),
     but we only want the nickname so we can use that as the display user when
@@ -96,7 +101,12 @@ def nick_from_irc_user(irc_user):
     return irc_user.split('!')[0]
 
 
-def format_irc_message(text, users, bots, channels):
+def format_irc_message(
+    text: str,
+    users: Dict[str, Any],
+    bots: Dict[str, Any],
+    channels: Dict[str, Any],
+) -> str:
     """
     Replace channels, users, commands, links, emoji, and any remaining stuff in
     messages from Slack to things that IRC users would have an easier time
@@ -106,7 +116,7 @@ def format_irc_message(text, users, bots, channels):
     https://github.com/ekmartin/slack-irc/blob/2b5ceb7ca7beb/lib/bot.js#L154
     """
 
-    def chan_replace(match):
+    def chan_replace(match: Match[str]) -> str:
         """
         Replace channel references (e.g. "<#C6QASJWLA|rebuild>" with
         "#rebuild") to make them more readable
@@ -115,7 +125,7 @@ def format_irc_message(text, users, bots, channels):
         readable = match.group(2)
         return '#{}'.format(readable or channels[chan_id])
 
-    def user_replace(match):
+    def user_replace(match: Match[str]) -> str:
         """
         Replace user references (e.g. "<@U0QHZCXST>" with "jvperrin-slack") to
         make them more readable. Uses the Slack user's IRC bot as the nick to
@@ -133,7 +143,7 @@ def format_irc_message(text, users, bots, channels):
             # This should never occur
             return 'unknown'
 
-    def var_replace(match):
+    def var_replace(match: Match[str]) -> str:
         """
         Replace any variables sent from Slack with more readable counterparts
         (e.g. <!var|label> will display as <label> instead)
@@ -142,7 +152,7 @@ def format_irc_message(text, users, bots, channels):
         label = match.group(2)
         return '<{}>'.format(label or var)
 
-    def emoji_replace(match):
+    def emoji_replace(match: Match[str]) -> str:
         """
         Replace any emoji from Slack with more text-readable equivalents if
         they exist in the EMOJIS dict mapping (e.g. ":smile:" maps to ":D")
@@ -179,7 +189,7 @@ def format_irc_message(text, users, bots, channels):
     return text
 
 
-def format_slack_message(text, users):
+def format_slack_message(text: str, users: Dict[str, Any]) -> str:
     """
     Strip any color codes coming from IRC, since Slack cannot display them
     The current solution is taken from https://stackoverflow.com/a/970723
@@ -190,7 +200,7 @@ def format_slack_message(text, users):
     TODO: Preserve bold and italics (convert to markdown?)
     """
 
-    def nick_replace(match):
+    def nick_replace(match: Match[str]) -> str:
         """
         Replace any IRC nick of the form keur-slack to <@keur> if it's in
         the provided list of Slack display names. To prevent accidental
@@ -209,7 +219,7 @@ def format_slack_message(text, users):
     return text
 
 
-def slack_api(slack_client, *args, **kwargs):
+def slack_api(slack_client: SlackClient, *args: Any, **kwargs: Any) -> Any:
     results = slack_client.api_call(*args, **kwargs)
     if results['ok']:
         return results


### PR DESCRIPTION
This makes mypy checking stricter (and also moves to using a config
file). The only question I faced when working on this was how to
represent the JSON responses of the Slack API. I decided on `Dict[str,
Any]`, which should be sufficient for now. Later if interested it would
be a fun project to convert these to
[TypedDict](https://mypy.readthedocs.io/en/latest/more_types.html#typeddict),
which would give us a bit more type safety. I will open an issue on that
once this is merged (and would happy to mentor that).