### PR TITLE
Updated legacy api call

### DIFF
--- a/slackbridge/main.py
+++ b/slackbridge/main.py
@@ -50,7 +50,7 @@ def main() -> None:
 
     # Get all channels from Slack
     log.msg('Requesting list of channels from Slack...')
-    results = slack_api(sc, 'channels.list', exclude_archived=True)
+    results = slack_api(sc, 'conversations.list', exclude_archived=True)
     slack_channels = results['channels']
 
     # Get a proper list of members for each channel. We're forced to do this by


### PR DESCRIPTION
Previously when gathering all channels using the old `channels.list` function, it would pick up channels with no members. The new `conversations.list` function does not have this problem.

I am also not sure how to best test if this change caused anything to go wrong. It seemed okay on dev-irc, but I am not confident without approval.