### PR TITLE
Add sample slackbridge.conf file (closes #88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,5 @@ config, run:
 
 instead, but if you are developing on supernova, you should not have to do this.
 `slackbridge.conf` contains the Slack API token, IRC NickServ password, etc. so
-it is meant to be kept secret.
+it is meant to be kept secret, but there is a sample config file provided at
+`slackbridge.conf.sample` to show the structure of the file.

--- a/slackbridge.conf.sample
+++ b/slackbridge.conf.sample
@@ -1,0 +1,15 @@
+[irc]
+# This is a nickserv password for the IRC bot. Currently the bot name is
+# hardcoded to 'slack-bridge' but it has many bots that join under the name of
+# '#{user}-slack' that will also be registered with the same nickserv pass.
+nickserv_pass=your_bot_nickserv_password
+
+[slack]
+# The token to authenticate to Slack with
+token=xoxb-00000000000-aaaaaaaaaaaaaaaaaaaaaaaa
+# This is the user ID of the bot user on the Slack side of things, this is just
+# used so that the bot knows who it is on Slack.
+#
+# TODO: Try to get this from Slack's API instead. users.identity doesn't appear
+# to work with legacy tokens, so this might need some authentication redesign
+user=UAAAAAAAA


### PR DESCRIPTION
This adds a sample config file (at `slackbridge.conf.sample`) to show the structure of it and briefly explain what each field is used for.