### PR TITLE
increase channel list limit to 500

### DIFF
--- a/slackbridge/main.py
+++ b/slackbridge/main.py
@@ -50,7 +50,12 @@ def main() -> None:
 
     # Get all channels from Slack
     log.msg('Requesting list of channels from Slack...')
-    results = slack_api(sc, 'conversations.list', exclude_archived=True)
+    results = slack_api(
+        sc,
+        'conversations.list',
+        limit=500,
+        exclude_archived=True,
+    )
     slack_channels = results['channels']
 
     # Get a proper list of members for each channel. We're forced to do this by


### PR DESCRIPTION
#decal-general (and apparently 11 other channels) were not getting bridged because they were cut off by pagination in Slack's API. This resolves the issue.