### PR TITLE
Log directly to stdout, remove runit/services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update \
         libffi-dev \
         libssl-dev \
         python3.7-dev \
-        runit \
         virtualenv \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -27,12 +26,9 @@ RUN chown -R nobody:nogroup /opt/slackbridge
 # cached layers makes rebuilding faster since it doesn't have to chown the whole
 # project again (including vendored stuff)
 COPY slackbridge /opt/slackbridge/slackbridge
-COPY services /opt/slackbridge/services
 RUN chown -R nobody:nogroup /opt/slackbridge/slackbridge
-RUN chown -R nobody:nogroup /opt/slackbridge/services
 
 USER nobody
 
 WORKDIR /opt/slackbridge
-ENV PATH=/opt/slackbridge/venv/bin:$PATH
-CMD ["runsvdir", "/opt/slackbridge/services"]
+CMD ["/opt/slackbridge/venv/bin/python", "-m", "slackbridge.main"]

--- a/services/bridge/log/run
+++ b/services/bridge/log/run
@@ -1,3 +1,0 @@
-#!/bin/bash
-set -euxo pipefail
-exec /opt/share/utils/sbin/stdin2syslog slackbridge

--- a/services/bridge/run
+++ b/services/bridge/run
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -euxo pipefail
-exec 2>&1
-cd /opt/slackbridge
-exec python -m slackbridge.main


### PR DESCRIPTION
I tested by building the image locally and running it (needed to specify a config file though to get it to work, so I did need to modify it to do that for actual testing. Seemed to all work fine though